### PR TITLE
Add asset inventory view and user assets tab

### DIFF
--- a/GUI/MandADiscoverySuite.xaml
+++ b/GUI/MandADiscoverySuite.xaml
@@ -779,10 +779,20 @@
                                                         <RowDefinition Height="Auto"/>
                                                     </Grid.RowDefinitions>
                                                     <TextBlock Grid.Row="0" Text="Infrastructure" Style="{StaticResource HeaderTextStyle}"/>
-                                                    <TextBlock Grid.Row="1" Text="Infrastructure content will be loaded here..." 
+                                                    <TextBlock Grid.Row="1" Text="Infrastructure content will be loaded here..."
                                                               Foreground="#FFA0AEC0" FontSize="16" Margin="0,16"/>
                                                 </Grid>
                                             </ScrollViewer>
+                                        </DataTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                            <!-- Assets Template -->
+                            <DataTrigger Binding="{Binding TabTitle}" Value="Assets">
+                                <Setter Property="ContentTemplate">
+                                    <Setter.Value>
+                                        <DataTemplate>
+                                            <views:AssetInventoryView/>
                                         </DataTemplate>
                                     </Setter.Value>
                                 </Setter>
@@ -1158,7 +1168,18 @@
                             </StackPanel>
                         </StackPanel>
                     </Button>
-                    
+
+                    <Button x:Name="AssetsButton" Style="{StaticResource NavButtonStyle}" Command="{Binding OpenTabCommand}" CommandParameter="Assets"
+                            ToolTip="View asset inventory">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="📦" FontSize="18" Margin="0,0,16,0"/>
+                            <StackPanel>
+                                <TextBlock Text="Assets"/>
+                                <TextBlock Text="Inventory" FontSize="10" Foreground="#FFA0AEC0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Button>
+
                     <Button x:Name="GroupsButton" Style="{StaticResource NavButtonStyle}" Command="{Binding OpenTabCommand}" CommandParameter="Groups"
                             ToolTip="Manage security groups, distribution lists, and group memberships">
                         <StackPanel Orientation="Horizontal">

--- a/GUI/Models/AssetData.cs
+++ b/GUI/Models/AssetData.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MandADiscoverySuite.Models
+{
+    /// <summary>
+    /// Represents an inventory asset with ownership information.
+    /// </summary>
+    public class AssetData : INotifyPropertyChanged
+    {
+        private string _name;
+        private string _type;
+        private string _owner;
+        private string _status;
+
+        public string Name
+        {
+            get => _name;
+            set { _name = value; OnPropertyChanged(); }
+        }
+
+        public string Type
+        {
+            get => _type;
+            set { _type = value; OnPropertyChanged(); }
+        }
+
+        public string Owner
+        {
+            get => _owner;
+            set { _owner = value; OnPropertyChanged(); }
+        }
+
+        public string Status
+        {
+            get => _status;
+            set { _status = value; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/GUI/ViewModels/AssetInventoryViewModel.cs
+++ b/GUI/ViewModels/AssetInventoryViewModel.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MandADiscoverySuite.Models;
+
+namespace MandADiscoverySuite.ViewModels
+{
+    /// <summary>
+    /// View model backing the asset inventory view.
+    /// </summary>
+    public class AssetInventoryViewModel : BaseViewModel
+    {
+        /// <summary>
+        /// Collection of all discovered assets.
+        /// </summary>
+        public ObservableCollection<AssetData> Assets { get; } = new ObservableCollection<AssetData>();
+
+        public AssetInventoryViewModel()
+        {
+            TabTitle = "Assets";
+        }
+
+        /// <summary>
+        /// Loads assets from discovery results.
+        /// </summary>
+        public void LoadAssets(IEnumerable<AssetData> discoveredAssets)
+        {
+            Assets.Clear();
+            if (discoveredAssets == null) return;
+            foreach (var asset in discoveredAssets)
+                Assets.Add(asset);
+        }
+
+        /// <summary>
+        /// Returns assets owned by the specified user.
+        /// </summary>
+        public IEnumerable<AssetData> GetAssetsForUser(string userName)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+                return Enumerable.Empty<AssetData>();
+            return Assets.Where(a => string.Equals(a.Owner, userName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/GUI/ViewModels/MainViewModel.cs
+++ b/GUI/ViewModels/MainViewModel.cs
@@ -4118,6 +4118,9 @@ This directory is strictly for storing discovery results and company data.
                     case "infrastructure":
                         tabViewModel = new InfrastructureViewModel { TabTitle = "Infrastructure" };
                         break;
+                    case "assets":
+                        tabViewModel = new AssetInventoryViewModel { TabTitle = "Assets" };
+                        break;
                     case "groups":
                         tabViewModel = new GroupsViewModel { TabTitle = "Groups" };
                         break;

--- a/GUI/ViewModels/UserDetailViewModel.cs
+++ b/GUI/ViewModels/UserDetailViewModel.cs
@@ -30,6 +30,7 @@ namespace MandADiscoverySuite.ViewModels
             DeviceRelationships = new ObservableCollection<DeviceRelationship>();
             DirectoryRoles = new ObservableCollection<DirectoryRole>();
             LicenseAssignments = new ObservableCollection<LicenseAssignment>();
+            Assets = new ObservableCollection<AssetData>();
             
             CloseCommand = new RelayCommand(() => CloseRequested?.Invoke());
             ExportProfileCommand = new RelayCommand(ExportProfile);
@@ -44,6 +45,7 @@ namespace MandADiscoverySuite.ViewModels
         public ObservableCollection<DeviceRelationship> DeviceRelationships { get; }
         public ObservableCollection<DirectoryRole> DirectoryRoles { get; }
         public ObservableCollection<LicenseAssignment> LicenseAssignments { get; }
+        public ObservableCollection<AssetData> Assets { get; }
         
         public ICommand CloseCommand { get; }
         public ICommand ExportProfileCommand { get; }
@@ -184,6 +186,7 @@ namespace MandADiscoverySuite.ViewModels
                 LoadGroupMemberships();
                 LoadApplicationAssignments();
                 LoadDeviceRelationships();
+                LoadAssets();
                 LoadDirectoryRoles();
                 LoadLicenses();
                 
@@ -312,6 +315,38 @@ namespace MandADiscoverySuite.ViewModels
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Error loading device relationships: {ex.Message}");
+            }
+        }
+
+        private void LoadAssets()
+        {
+            try
+            {
+                Assets.Clear();
+                foreach (var device in DeviceRelationships)
+                {
+                    Assets.Add(new AssetData
+                    {
+                        Name = device.DisplayName,
+                        Type = device.DeviceType,
+                        Owner = DisplayName,
+                        Status = device.Status
+                    });
+                }
+                if (Assets.Count == 0)
+                {
+                    Assets.Add(new AssetData
+                    {
+                        Name = "No assets found",
+                        Type = string.Empty,
+                        Owner = string.Empty,
+                        Status = string.Empty
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error loading assets: {ex.Message}");
             }
         }
         

--- a/GUI/Views/AssetInventoryView.xaml
+++ b/GUI/Views/AssetInventoryView.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="MandADiscoverySuite.Views.AssetInventoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid>
+        <DataGrid x:Name="AssetGrid" ItemsSource="{Binding Assets}" AutoGenerateColumns="False" IsReadOnly="True"
+                  MouseDoubleClick="AssetGrid_MouseDoubleClick">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="150"/>
+                <DataGridTextColumn Header="Owner" Binding="{Binding Owner}" Width="150"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="100"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/GUI/Views/AssetInventoryView.xaml.cs
+++ b/GUI/Views/AssetInventoryView.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.Services;
+
+namespace MandADiscoverySuite.Views
+{
+    public partial class AssetInventoryView : UserControl
+    {
+        public AssetInventoryView()
+        {
+            InitializeComponent();
+        }
+
+        private void AssetGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is DataGrid grid && grid.SelectedItem is AssetData asset && !string.IsNullOrEmpty(asset.Owner))
+            {
+                // For demo purposes we use the owner's name to resolve data path.
+                var rawPath = ConfigurationService.Instance.GetCompanyRawDataPath("DefaultCompany");
+                var window = new UserDetailWindow(new { DisplayName = asset.Owner }, rawPath);
+                window.Owner = Window.GetWindow(this);
+                window.ShowDialog();
+            }
+        }
+    }
+}

--- a/GUI/Views/UserDetailWindow.xaml
+++ b/GUI/Views/UserDetailWindow.xaml
@@ -196,6 +196,30 @@
                 </Grid>
             </TabItem>
 
+            <!-- Assets Tab -->
+            <TabItem Header="Assets">
+                <Grid Margin="20">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,15">
+                        <TextBlock Text="Assigned Assets" Style="{StaticResource HeaderStyle}" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding Assets.Count, StringFormat='({0} assets)'}" FontSize="14" Foreground="Gray" VerticalAlignment="Bottom" Margin="10,0,0,5"/>
+                    </StackPanel>
+
+                    <DataGrid Grid.Row="1" ItemsSource="{Binding Assets}" AutoGenerateColumns="False" IsReadOnly="True" GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                            <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="150"/>
+                            <DataGridTextColumn Header="Owner" Binding="{Binding Owner}" Width="150"/>
+                            <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="100"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Grid>
+            </TabItem>
+
             <!-- Attributes Tab -->
             <TabItem Header="Attributes">
                 <Grid Margin="20">


### PR DESCRIPTION
## Summary
- Add AssetData model and AssetInventoryView to list assets
- Extend user detail window with Assets tab showing user-linked assets
- Hook navigation to new Assets view and enable opening user detail from assets

## Testing
- `dotnet build GUI/MandADiscoverySuite.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960d61b8888333b67de0ae3e9f1c81