### PR TITLE
Display inventory metrics on project management dashboard

### DIFF
--- a/GUI/ViewModels/ProjectManagementDashboardViewModel.cs
+++ b/GUI/ViewModels/ProjectManagementDashboardViewModel.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
+using MandADiscoverySuite.Messages;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.Services;
+
+namespace MandADiscoverySuite.ViewModels
+{
+    /// <summary>
+    /// ViewModel for the Project Management Dashboard metrics.
+    /// </summary>
+    public class ProjectManagementDashboardViewModel : BaseViewModel, IRecipient<DiscoveryCompletedMessage>
+    {
+        private readonly IDataService _dataService;
+        private string _profileName = "DefaultCompany";
+        private int _totalUsers;
+        private int _totalAssets;
+        private int _totalApplications;
+        private int _pendingMigrations;
+        private IntegrationProject _currentProject;
+
+        public ProjectManagementDashboardViewModel(IDataService dataService = null, ILogger<ProjectManagementDashboardViewModel> logger = null, IMessenger messenger = null)
+            : base(logger, messenger)
+        {
+            _dataService = dataService ?? new CsvDataService();
+
+            RefreshMetricsCommand = new AsyncRelayCommand(RefreshMetricsAsync);
+            NavigateUsersCommand = new RelayCommand(() => Messenger.Send(new NavigationMessage("Users")));
+            NavigateAssetsCommand = new RelayCommand(() => Messenger.Send(new NavigationMessage("Infrastructure")));
+            NavigateApplicationsCommand = new RelayCommand(() => Messenger.Send(new NavigationMessage("Applications")));
+            NavigateMigrationsCommand = new RelayCommand(() => Messenger.Send(new NavigationMessage("TaskScheduler")));
+
+            Messenger.Register<DiscoveryCompletedMessage>(this);
+        }
+
+        #region Properties
+
+        public int TotalUsers
+        {
+            get => _totalUsers;
+            set => SetProperty(ref _totalUsers, value);
+        }
+
+        public int TotalAssets
+        {
+            get => _totalAssets;
+            set => SetProperty(ref _totalAssets, value);
+        }
+
+        public int TotalApplications
+        {
+            get => _totalApplications;
+            set => SetProperty(ref _totalApplications, value);
+        }
+
+        public int PendingMigrations
+        {
+            get => _pendingMigrations;
+            set => SetProperty(ref _pendingMigrations, value);
+        }
+
+        /// <summary>
+        /// Current integration project used to calculate pending migrations.
+        /// </summary>
+        public IntegrationProject CurrentProject
+        {
+            get => _currentProject;
+            set
+            {
+                if (SetProperty(ref _currentProject, value))
+                {
+                    UpdatePendingMigrations();
+                }
+            }
+        }
+
+        #endregion
+
+        #region Commands
+
+        public ICommand RefreshMetricsCommand { get; }
+        public ICommand NavigateUsersCommand { get; }
+        public ICommand NavigateAssetsCommand { get; }
+        public ICommand NavigateApplicationsCommand { get; }
+        public ICommand NavigateMigrationsCommand { get; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Refreshes metric values from the data service.
+        /// </summary>
+        public async Task RefreshMetricsAsync()
+        {
+            try
+            {
+                IsLoading = true;
+                var summary = await _dataService.GetDataSummaryAsync(_profileName);
+                TotalUsers = summary.TotalUsers;
+                TotalAssets = summary.TotalComputers;
+                TotalApplications = summary.TotalApplications;
+                UpdatePendingMigrations();
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+
+        private void UpdatePendingMigrations()
+        {
+            if (CurrentProject == null)
+            {
+                PendingMigrations = 0;
+                return;
+            }
+
+            var count = CurrentProject.Phases
+                .SelectMany(p => p.Components)
+                .SelectMany(c => c.Tasks)
+                .Count(t => t.Name?.IndexOf("migration", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                            t.Status != TaskStatus.Completed);
+            PendingMigrations = count;
+        }
+
+        public void Receive(DiscoveryCompletedMessage message)
+        {
+            _profileName = message.ProfileName;
+            RefreshMetricsCommand.Execute(null);
+        }
+
+        #endregion
+    }
+}

--- a/GUI/Views/ProjectManagementDashboard.xaml
+++ b/GUI/Views/ProjectManagementDashboard.xaml
@@ -1,9 +1,10 @@
 <UserControl x:Class="MandADiscoverySuite.Views.ProjectManagementDashboard"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="clr-namespace:MandADiscoverySuite.Controls"
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <Grid.RowDefinitions>
@@ -20,7 +21,35 @@
         <!-- Content -->
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="10">
-                <TextBlock Text="Project management dashboard content goes here..." 
+                <!-- Metrics -->
+                <UniformGrid Columns="4" Margin="0,0,0,20">
+                    <Button Command="{Binding NavigateUsersCommand}"
+                            Background="Transparent" BorderBrush="Transparent" Padding="0">
+                        <controls:AnimatedMetricCard Title="Users"
+                                                      Value="{Binding TotalUsers}"
+                                                      Icon="👤"/>
+                    </Button>
+                    <Button Command="{Binding NavigateAssetsCommand}"
+                            Background="Transparent" BorderBrush="Transparent" Padding="0">
+                        <controls:AnimatedMetricCard Title="Assets"
+                                                      Value="{Binding TotalAssets}"
+                                                      Icon="💻"/>
+                    </Button>
+                    <Button Command="{Binding NavigateApplicationsCommand}"
+                            Background="Transparent" BorderBrush="Transparent" Padding="0">
+                        <controls:AnimatedMetricCard Title="Applications"
+                                                      Value="{Binding TotalApplications}"
+                                                      Icon="📦"/>
+                    </Button>
+                    <Button Command="{Binding NavigateMigrationsCommand}"
+                            Background="Transparent" BorderBrush="Transparent" Padding="0">
+                        <controls:AnimatedMetricCard Title="Pending Migrations"
+                                                      Value="{Binding PendingMigrations}"
+                                                      Icon="🚚"/>
+                    </Button>
+                </UniformGrid>
+
+                <TextBlock Text="Project management dashboard content goes here..."
                           Style="{DynamicResource BodyTextStyle}"/>
             </StackPanel>
         </ScrollViewer>

--- a/GUI/Views/ProjectManagementDashboard.xaml.cs
+++ b/GUI/Views/ProjectManagementDashboard.xaml.cs
@@ -1,4 +1,6 @@
+using System.Windows;
 using System.Windows.Controls;
+using MandADiscoverySuite.ViewModels;
 
 namespace MandADiscoverySuite.Views
 {
@@ -7,9 +9,19 @@ namespace MandADiscoverySuite.Views
     /// </summary>
     public partial class ProjectManagementDashboard : UserControl
     {
+        private readonly ProjectManagementDashboardViewModel _viewModel;
+
         public ProjectManagementDashboard()
         {
             InitializeComponent();
+            _viewModel = new ProjectManagementDashboardViewModel();
+            DataContext = _viewModel;
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            _viewModel.RefreshMetricsCommand.Execute(null);
         }
     }
 }

--- a/Tests/MandADiscoverySuite.Tests.csproj
+++ b/Tests/MandADiscoverySuite.Tests.csproj
@@ -1,28 +1,25 @@
-&lt;Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
 
-  &lt;PropertyGroup>
-    &lt;TargetFramework>net6.0&lt;/TargetFramework>
-    &lt;IsPackable>false&lt;/IsPackable>
-    &lt;Nullable>disable&lt;/Nullable>
-  &lt;/PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-  &lt;ItemGroup>
-    &lt;PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    &lt;PackageReference Include="xunit" Version="2.6.1" />
-    &lt;PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      &lt;IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive&lt;/IncludeAssets>
-      &lt;PrivateAssets>all&lt;/PrivateAssets>
-    &lt;/PackageReference>
-    &lt;PackageReference Include="Moq" Version="4.20.69" />
-    &lt;PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="8.0.0" />
-    &lt;PackageReference Include="coverlet.collector" Version="6.0.0">
-      &lt;IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive&lt;/IncludeAssets>
-      &lt;PrivateAssets>all&lt;/PrivateAssets>
-    &lt;/PackageReference>
-  &lt;/ItemGroup>
-
-  &lt;ItemGroup>
-    &lt;ProjectReference Include="..\GUI\MandADiscoverySuite.csproj" />
-  &lt;/ItemGroup>
-
-&lt;/Project>
+  <ItemGroup>
+    <ProjectReference Include="..\GUI\MandADiscoverySuite.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/ViewModels/ProjectManagementDashboardViewModelTests.cs
+++ b/Tests/ViewModels/ProjectManagementDashboardViewModelTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using MandADiscoverySuite.Messages;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.Services;
+using MandADiscoverySuite.ViewModels;
+using Xunit;
+
+namespace MandADiscoverySuite.Tests.ViewModels
+{
+    public class ProjectManagementDashboardViewModelTests
+    {
+        private class FakeDataService : IDataService
+        {
+            public DataSummary Summary { get; set; } = new DataSummary();
+
+            public Task<IEnumerable<UserData>> LoadUsersAsync(string profileName, bool forceRefresh = false, CancellationToken cancellationToken = default) =>
+                Task.FromResult<IEnumerable<UserData>>(Array.Empty<UserData>());
+            public Task<IEnumerable<InfrastructureData>> LoadInfrastructureAsync(string profileName, bool forceRefresh = false, CancellationToken cancellationToken = default) =>
+                Task.FromResult<IEnumerable<InfrastructureData>>(Array.Empty<InfrastructureData>());
+            public Task<IEnumerable<GroupData>> LoadGroupsAsync(string profileName, bool forceRefresh = false, CancellationToken cancellationToken = default) =>
+                Task.FromResult<IEnumerable<GroupData>>(Array.Empty<GroupData>());
+            public Task<IEnumerable<ApplicationData>> LoadApplicationsAsync(string profileName, bool forceRefresh = false, CancellationToken cancellationToken = default) =>
+                Task.FromResult<IEnumerable<ApplicationData>>(Array.Empty<ApplicationData>());
+            public Task<DataSummary> GetDataSummaryAsync(string profileName, CancellationToken cancellationToken = default) =>
+                Task.FromResult(Summary);
+            public Task<SearchResults> SearchAsync(string profileName, string searchTerm, SearchOptions searchOptions = null, CancellationToken cancellationToken = default) =>
+                Task.FromResult(new SearchResults());
+            public Task<ExportResult> ExportDataAsync(string profileName, ExportOptions exportOptions, CancellationToken cancellationToken = default) =>
+                Task.FromResult(new ExportResult());
+            public Task ClearCacheAsync(string profileName) => Task.CompletedTask;
+            public Task<CacheStatistics> GetCacheStatisticsAsync() => Task.FromResult(new CacheStatistics());
+        }
+
+        [Fact]
+        public async Task RefreshMetricsAsync_PopulatesCounts()
+        {
+            var messenger = new WeakReferenceMessenger();
+            var dataService = new FakeDataService
+            {
+                Summary = new DataSummary
+                {
+                    TotalUsers = 10,
+                    TotalComputers = 5,
+                    TotalApplications = 3
+                }
+            };
+
+            var vm = new ProjectManagementDashboardViewModel(dataService, messenger: messenger);
+            var project = new IntegrationProject();
+            var phase = new ProjectPhase();
+            var component = new ProjectComponent();
+            component.Tasks.Add(new ProjectTask { Name = "Database Migration", Status = TaskStatus.InProgress });
+            component.Tasks.Add(new ProjectTask { Name = "Completed Migration", Status = TaskStatus.Completed });
+            phase.Components.Add(component);
+            project.Phases.Add(phase);
+            vm.CurrentProject = project;
+
+            await vm.RefreshMetricsAsync();
+
+            Assert.Equal(10, vm.TotalUsers);
+            Assert.Equal(5, vm.TotalAssets);
+            Assert.Equal(3, vm.TotalApplications);
+            Assert.Equal(1, vm.PendingMigrations);
+        }
+
+        [Fact]
+        public async Task DiscoveryCompletedMessage_TriggersRefresh()
+        {
+            var messenger = new WeakReferenceMessenger();
+            var dataService = new FakeDataService
+            {
+                Summary = new DataSummary { TotalUsers = 1, TotalComputers = 1, TotalApplications = 1 }
+            };
+
+            var vm = new ProjectManagementDashboardViewModel(dataService, messenger: messenger);
+            await vm.RefreshMetricsAsync();
+            Assert.Equal(1, vm.TotalUsers);
+
+            dataService.Summary = new DataSummary { TotalUsers = 2, TotalComputers = 3, TotalApplications = 4 };
+            messenger.Send(new DiscoveryCompletedMessage("DefaultCompany", true));
+            await Task.Delay(50); // allow async refresh
+
+            Assert.Equal(2, vm.TotalUsers);
+            Assert.Equal(3, vm.TotalAssets);
+            Assert.Equal(4, vm.TotalApplications);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show user, asset, application, and migration metrics with animated cards on project dashboard
- add ProjectManagementDashboardViewModel to load metrics and handle navigation
- include unit tests for dashboard metric updates

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960d86bfac8333a45fb2f28580172e