### PR TITLE
Add security group inventory view and metadata columns

### DIFF
--- a/GUI/Models/DetailWindowModels.cs
+++ b/GUI/Models/DetailWindowModels.cs
@@ -380,8 +380,23 @@ namespace MandADiscoverySuite.Models
     {
         public string DisplayName { get; set; }
         public string GroupType { get; set; }
+        public string Scope { get; set; }
         public string Description { get; set; }
+        public bool IsNested { get; set; }
         public DateTime? MemberSince { get; set; }
+    }
+
+    /// <summary>
+    /// Basic security group information used in inventory views
+    /// </summary>
+    public class SecurityGroupInfo
+    {
+        public string Name { get; set; }
+        public string GroupType { get; set; }
+        public string Scope { get; set; }
+        public string Description { get; set; }
+        public bool IsNested { get; set; }
+        public string SamAccountName { get; set; }
     }
 
     /// <summary>

--- a/GUI/UserDetailWindow.xaml
+++ b/GUI/UserDetailWindow.xaml
@@ -170,6 +170,9 @@
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="Group Name" Binding="{Binding DisplayName}" Width="*"/>
                                         <DataGridTextColumn Header="Type" Binding="{Binding GroupType}" Width="80"/>
+                                        <DataGridTextColumn Header="Scope" Binding="{Binding Scope}" Width="80"/>
+                                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="200"/>
+                                        <DataGridCheckBoxColumn Header="Nested" Binding="{Binding IsNested}" Width="60"/>
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </StackPanel>

--- a/GUI/ViewModels/SecurityGroupInventoryViewModel.cs
+++ b/GUI/ViewModels/SecurityGroupInventoryViewModel.cs
@@ -1,0 +1,46 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.Services;
+
+namespace MandADiscoverySuite.ViewModels
+{
+    public class SecurityGroupInventoryViewModel : BaseViewModel
+    {
+        private readonly IDetailWindowService _detailWindowService;
+        public ObservableCollection<SecurityGroupInfo> Groups { get; }
+
+        private SecurityGroupInfo _selectedGroup;
+        public SecurityGroupInfo SelectedGroup
+        {
+            get => _selectedGroup;
+            set { _selectedGroup = value; OnPropertyChanged(); }
+        }
+
+        public ICommand OpenGroupCommand { get; }
+
+        public SecurityGroupInventoryViewModel() : this(new DetailWindowService()) { }
+
+        public SecurityGroupInventoryViewModel(IDetailWindowService detailWindowService)
+        {
+            _detailWindowService = detailWindowService;
+            Groups = new ObservableCollection<SecurityGroupInfo>();
+            OpenGroupCommand = new AsyncRelayCommand(OpenSelectedGroupAsync, () => SelectedGroup != null);
+        }
+
+        private async Task OpenSelectedGroupAsync()
+        {
+            if (SelectedGroup == null) return;
+            var detail = new GroupDetailData
+            {
+                Id = SelectedGroup.SamAccountName,
+                GroupName = SelectedGroup.Name,
+                Description = SelectedGroup.Description,
+                GroupType = SelectedGroup.GroupType,
+                Scope = SelectedGroup.Scope
+            };
+            await _detailWindowService.ShowDetailWindowAsync(detail);
+        }
+    }
+}

--- a/GUI/Views/SecurityGroupInventoryView.xaml
+++ b/GUI/Views/SecurityGroupInventoryView.xaml
@@ -1,0 +1,16 @@
+<UserControl x:Class="MandADiscoverySuite.Views.SecurityGroupInventoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <DataGrid ItemsSource="{Binding Groups}"
+                  AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Group Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Type" Binding="{Binding GroupType}" Width="100"/>
+                <DataGridTextColumn Header="Scope" Binding="{Binding Scope}" Width="100"/>
+                <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="200"/>
+                <DataGridCheckBoxColumn Header="Nested" Binding="{Binding IsNested}" Width="60"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/GUI/Views/SecurityGroupInventoryView.xaml.cs
+++ b/GUI/Views/SecurityGroupInventoryView.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows.Controls;
+using MandADiscoverySuite.ViewModels;
+
+namespace MandADiscoverySuite.Views
+{
+    public partial class SecurityGroupInventoryView : UserControl
+    {
+        public SecurityGroupInventoryView()
+        {
+            InitializeComponent();
+            DataContext = new SecurityGroupInventoryViewModel();
+        }
+    }
+}

--- a/Modules/Discovery/ActiveDirectoryDiscovery.psm1
+++ b/Modules/Discovery/ActiveDirectoryDiscovery.psm1
@@ -443,7 +443,7 @@ function Get-ADGroupsData {
         $groupProperties = @(
             'SamAccountName', 'Name', 'GroupCategory', 'GroupScope',
             'Description', 'DistinguishedName', 'whenCreated', 'whenChanged',
-            'mail', 'ManagedBy', 'member'
+            'mail', 'ManagedBy', 'member', 'memberOf'
         )
         
         $adGroups = Get-ADGroup -Filter * -Properties $groupProperties @ServerParams -ErrorAction Stop
@@ -462,6 +462,7 @@ function Get-ADGroupsData {
                 EmailAddress = $group.mail
                 ManagedBy = $group.ManagedBy
                 MemberCount = if ($group.member) { $group.member.Count } else { 0 }
+                IsNested = if ($group.memberOf) { $true } else { $false }
             }
             $null = $groups.Add($groupObj)
             

--- a/Modules/Storage/DatabaseStorageEngine.psm1
+++ b/Modules/Storage/DatabaseStorageEngine.psm1
@@ -154,6 +154,7 @@ class DatabaseStorageEngine {
                     Description TEXT,
                     ManagedBy TEXT,
                     MemberCount INTEGER DEFAULT 0,
+                    IsNested INTEGER DEFAULT 0,
                     CreatedDate DATETIME,
                     ModifiedDate DATETIME,
                     DistinguishedName TEXT,

--- a/Tests/MandADiscoverySuite.Tests.csproj
+++ b/Tests/MandADiscoverySuite.Tests.csproj
@@ -1,28 +1,27 @@
-&lt;Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  &lt;PropertyGroup>
-    &lt;TargetFramework>net6.0&lt;/TargetFramework>
-    &lt;IsPackable>false&lt;/IsPackable>
-    &lt;Nullable>disable&lt;/Nullable>
-  &lt;/PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
 
-  &lt;ItemGroup>
-    &lt;PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    &lt;PackageReference Include="xunit" Version="2.6.1" />
-    &lt;PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      &lt;IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive&lt;/IncludeAssets>
-      &lt;PrivateAssets>all&lt;/PrivateAssets>
-    &lt;/PackageReference>
-    &lt;PackageReference Include="Moq" Version="4.20.69" />
-    &lt;PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="8.0.0" />
-    &lt;PackageReference Include="coverlet.collector" Version="6.0.0">
-      &lt;IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive&lt;/IncludeAssets>
-      &lt;PrivateAssets>all&lt;/PrivateAssets>
-    &lt;/PackageReference>
-  &lt;/ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-  &lt;ItemGroup>
-    &lt;ProjectReference Include="..\GUI\MandADiscoverySuite.csproj" />
-  &lt;/ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GUI\MandADiscoverySuite.csproj" />
+  </ItemGroup>
 
-&lt;/Project>
+</Project>

--- a/Tests/ViewModels/SecurityGroupInventoryViewModelTests.cs
+++ b/Tests/ViewModels/SecurityGroupInventoryViewModelTests.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.ViewModels;
+using MandADiscoverySuite.Services;
+using Moq;
+using Xunit;
+
+namespace MandADiscoverySuite.Tests.ViewModels
+{
+    public class SecurityGroupInventoryViewModelTests
+    {
+        [Fact]
+        public async Task OpenGroupCommand_InvokesDetailWindowService()
+        {
+            var mockService = new Mock<IDetailWindowService>();
+            mockService.Setup(s => s.ShowDetailWindowAsync(It.IsAny<GroupDetailData>(), null))
+                       .Returns(Task.FromResult<System.Windows.Window>(null))
+                       .Verifiable();
+
+            var vm = new SecurityGroupInventoryViewModel(mockService.Object);
+            vm.Groups.Add(new SecurityGroupInfo { Name = "Group One", SamAccountName = "grp1", GroupType = "Security", Scope = "Global" });
+            vm.SelectedGroup = vm.Groups[0];
+
+            vm.OpenGroupCommand.Execute(null);
+            await Task.Delay(50);
+
+            mockService.Verify();
+        }
+    }
+}

--- a/Tests/ViewModels/UserDetailViewModelTests.cs
+++ b/Tests/ViewModels/UserDetailViewModelTests.cs
@@ -1,0 +1,41 @@
+using System.Dynamic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MandADiscoverySuite.ViewModels;
+using Xunit;
+
+namespace MandADiscoverySuite.Tests.ViewModels
+{
+    public class UserDetailViewModelTests
+    {
+        [Fact]
+        public async Task LoadGroupMembershipsAsync_LoadsExtendedMetadata()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+            var csvPath = Path.Combine(tempDir, "Groups.csv");
+            var csv = "SamAccountName,Name,GroupCategory,GroupScope,Description,IsNested,Members\n" +
+                      "grp1,Group One,Security,Global,First group,false,user1;user2\n" +
+                      "grp2,Group Two,Security,Universal,Second group,true,user3\n";
+            File.WriteAllText(csvPath, csv);
+
+            dynamic user = new ExpandoObject();
+            user.Id = "user1";
+            user.DisplayName = "User One";
+
+            var vm = new UserDetailViewModel(user, tempDir);
+            await Task.Delay(200);
+
+            Assert.Single(vm.GroupMemberships);
+            var g = vm.GroupMemberships.First();
+            Assert.Equal("Group One", g.DisplayName);
+            Assert.Equal("Security", g.GroupType);
+            Assert.Equal("Global", g.Scope);
+            Assert.Equal("First group", g.Description);
+            Assert.False(g.IsNested);
+
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Show group type, scope, description, and nested flags in User Detail group list
- Record group scope and nesting in discovery and storage layers
- Introduce SecurityGroupInventoryView and ViewModel with basic navigation
- Add unit tests for group metadata loading and inventory navigation

## Testing
- `dotnet test` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.118/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68960d6cea38833398760e15b362eb93