### PR TITLE
Add application inventory view and user application mappings

### DIFF
--- a/GUI/Models/DiscoveryModels.cs
+++ b/GUI/Models/DiscoveryModels.cs
@@ -672,7 +672,10 @@ namespace MandADiscoverySuite.Models
 
         public string Id { get; set; }
         public string ObjectType { get; set; }
-        
+        public List<string> UserIds { get; set; } = new List<string>();
+        public List<string> UserIds { get; set; } = new List<string>();
+        public List<string> UserIds { get; set; } = new List<string>();
+
         public bool IsSelected
         {
             get => _isSelected;
@@ -722,6 +725,7 @@ namespace MandADiscoverySuite.Models
         }
 
         // Additional properties from CSV
+        public List<string> ApplicationIds { get; set; } = new List<string>();
         public string GivenName { get; set; }
         public string Surname { get; set; }
         public string CompanyName { get; set; }
@@ -771,6 +775,7 @@ namespace MandADiscoverySuite.Models
 
         public string Id { get; set; }
         public string ObjectType { get; set; }
+        public List<string> UserIds { get; set; } = new List<string>();
 
         public bool IsSelected
         {
@@ -844,6 +849,7 @@ namespace MandADiscoverySuite.Models
 
         public string Id { get; set; }
         public string ObjectType { get; set; }
+        public List<string> UserIds { get; set; } = new List<string>();
 
         public bool IsSelected
         {
@@ -928,6 +934,7 @@ namespace MandADiscoverySuite.Models
 
         public string Id { get; set; }
         public string ObjectType { get; set; }
+        public List<string> UserIds { get; set; } = new List<string>();
 
         public bool IsSelected
         {

--- a/GUI/Services/CsvDataService.cs
+++ b/GUI/Services/CsvDataService.cs
@@ -683,6 +683,14 @@ namespace MandADiscoverySuite.Services
                                 case "urlinfoabout":
                                     application.URLInfoAbout = value;
                                     break;
+                                case "userids":
+                                case "assigneduserids":
+                                case "users":
+                                    application.UserIds = value
+                                        .Split(new[] { ';', ',', '|' }, StringSplitOptions.RemoveEmptyEntries)
+                                        .Select(u => u.Trim())
+                                        .ToList();
+                                    break;
                             }
                         }
 
@@ -1041,12 +1049,28 @@ namespace MandADiscoverySuite.Services
                 var applications = await LoadApplicationsAsync(dataPath);
                 allApplications.AddRange(applications);
             }
-            
+
             // Remove duplicates based on Name and Version
             allApplications = allApplications
                 .GroupBy(a => new { a.Name, a.Version })
                 .Select(g => g.First())
                 .ToList();
+
+            // Map applications to users
+            var users = (await LoadUsersAsync(profileName, forceRefresh, cancellationToken)).ToList();
+            var userLookup = users.ToDictionary(u => u.Id, u => u);
+            foreach (var app in allApplications)
+            {
+                if (app.UserIds == null) continue;
+                foreach (var userId in app.UserIds)
+                {
+                    if (userLookup.TryGetValue(userId, out var user))
+                    {
+                        if (!user.ApplicationIds.Contains(app.Id))
+                            user.ApplicationIds.Add(app.Id);
+                    }
+                }
+            }
             
             if (_cacheService != null)
             {

--- a/GUI/UserDetailWindow.xaml
+++ b/GUI/UserDetailWindow.xaml
@@ -104,8 +104,10 @@
             </Border>
 
             <!-- Main Content -->
-            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="20">
-                <Grid>
+            <TabControl Grid.Row="1" Background="Transparent">
+                <TabItem Header="Overview">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="20">
+                        <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
@@ -170,20 +172,6 @@
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="Group Name" Binding="{Binding DisplayName}" Width="*"/>
                                         <DataGridTextColumn Header="Type" Binding="{Binding GroupType}" Width="80"/>
-                                    </DataGrid.Columns>
-                                </DataGrid>
-                            </StackPanel>
-                        </Border>
-
-                        <!-- Application Assignments Card -->
-                        <Border Style="{StaticResource ModernCardStyle}">
-                            <StackPanel>
-                                <TextBlock Text="📱 Application Access" Style="{StaticResource SectionHeaderStyle}"/>
-                                <DataGrid x:Name="ApplicationsGrid" ItemsSource="{Binding ApplicationAssignments}" Style="{StaticResource CompactDataGridStyle}" MaxHeight="200"
-                                          VirtualizingStackPanel.IsVirtualizing="True" EnableRowVirtualization="True" EnableColumnVirtualization="True">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Application" Binding="{Binding DisplayName}" Width="*"/>
-                                        <DataGridTextColumn Header="Role" Binding="{Binding Role}" Width="100"/>
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </StackPanel>
@@ -270,7 +258,18 @@
 
                     </StackPanel>
                 </Grid>
-            </ScrollViewer>
+                    </ScrollViewer>
+                </TabItem>
+                <TabItem Header="Applications">
+                    <DataGrid ItemsSource="{Binding ApplicationAssignments}" Style="{StaticResource CompactDataGridStyle}" Margin="20"
+                              VirtualizingStackPanel.IsVirtualizing="True" EnableRowVirtualization="True" EnableColumnVirtualization="True">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Application" Binding="{Binding DisplayName}" Width="*"/>
+                            <DataGridTextColumn Header="Role" Binding="{Binding Role}" Width="100"/>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </TabItem>
+            </TabControl>
 
             <!-- Action Buttons -->
             <Border Grid.Row="2" Background="#FF2D3748" CornerRadius="0,0,12,12" Padding="20,16">

--- a/GUI/ViewModels/ApplicationInventoryViewModel.cs
+++ b/GUI/ViewModels/ApplicationInventoryViewModel.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Input;
+using MandADiscoverySuite.Models;
+using MandADiscoverySuite.Services;
+using MandADiscoverySuite.Collections;
+
+namespace MandADiscoverySuite.ViewModels
+{
+    /// <summary>
+    /// ViewModel for displaying application inventory with filtering capabilities
+    /// </summary>
+    public class ApplicationInventoryViewModel : BaseViewModel
+    {
+        private readonly CsvDataService _csvDataService;
+        private ICollectionView _applicationsView;
+        private string _searchText = string.Empty;
+        private string _dataDirectory;
+
+        public OptimizedObservableCollection<ApplicationData> Applications { get; }
+
+        public ICollectionView ApplicationsView
+        {
+            get => _applicationsView;
+            private set => SetProperty(ref _applicationsView, value);
+        }
+
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                if (SetProperty(ref _searchText, value))
+                {
+                    ApplicationsView?.Refresh();
+                }
+            }
+        }
+
+        public ICommand RefreshApplicationsCommand { get; }
+        public ICommand ClearSearchCommand { get; }
+
+        public ApplicationInventoryViewModel(CsvDataService csvDataService = null)
+        {
+            _csvDataService = csvDataService ?? new CsvDataService();
+            Applications = new OptimizedObservableCollection<ApplicationData>();
+            ApplicationsView = CollectionViewSource.GetDefaultView(Applications);
+            ApplicationsView.Filter = FilterApplications;
+
+            RefreshApplicationsCommand = new AsyncRelayCommand(RefreshApplicationsAsync);
+            ClearSearchCommand = new RelayCommand(() => SearchText = string.Empty);
+        }
+
+        public async Task InitializeAsync(string dataDirectory)
+        {
+            _dataDirectory = dataDirectory;
+            await RefreshApplicationsAsync();
+        }
+
+        private bool FilterApplications(object obj)
+        {
+            if (obj is not ApplicationData app)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(SearchText))
+                return true;
+
+            return (app.Name?.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase) >= 0) ||
+                   (app.Publisher?.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private async Task RefreshApplicationsAsync()
+        {
+            if (string.IsNullOrWhiteSpace(_dataDirectory))
+                return;
+
+            IsLoading = true;
+            try
+            {
+                var apps = await _csvDataService.LoadApplicationsAsync(_dataDirectory);
+                Applications.Clear();
+                foreach (var app in apps)
+                {
+                    Applications.Add(app);
+                }
+                ApplicationsView.Refresh();
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+    }
+}

--- a/GUI/ViewModels/UserDetailViewModel.cs
+++ b/GUI/ViewModels/UserDetailViewModel.cs
@@ -273,20 +273,32 @@ namespace MandADiscoverySuite.ViewModels
             {
                 ApplicationAssignments.Clear();
                 string applicationsFile = Path.Combine(_rawDataPath, "Applications.csv");
-                
-                if (File.Exists(applicationsFile))
+
+                if (File.Exists(applicationsFile) && !string.IsNullOrEmpty(_userData?.Id))
                 {
-                    var appLines = File.ReadAllLines(applicationsFile).Skip(1);
-                    foreach (var line in appLines)
+                    var lines = File.ReadAllLines(applicationsFile);
+                    if (lines.Length > 1)
                     {
-                        var parts = ParseCsvLine(line);
-                        if (parts.Length > 10)
+                        var headers = ParseCsvLine(lines[0]);
+                        int nameIndex = Array.FindIndex(headers, h => h.Equals("displayname", StringComparison.OrdinalIgnoreCase) || h.Equals("name", StringComparison.OrdinalIgnoreCase));
+                        int userIdsIndex = Array.FindIndex(headers, h => h.Equals("userids", StringComparison.OrdinalIgnoreCase) || h.Equals("assigneduserids", StringComparison.OrdinalIgnoreCase) || h.Equals("users", StringComparison.OrdinalIgnoreCase));
+
+                        for (int i = 1; i < lines.Length; i++)
                         {
-                            ApplicationAssignments.Add(new ApplicationAssignment
+                            var parts = ParseCsvLine(lines[i]);
+                            if (parts.Length <= Math.Max(nameIndex, userIdsIndex))
+                                continue;
+
+                            var userIds = userIdsIndex >= 0 ? parts[userIdsIndex] : string.Empty;
+                            if (!string.IsNullOrEmpty(userIds) && userIds.Split(new[] { ';', ',', '|' }, StringSplitOptions.RemoveEmptyEntries).Any(id => id.Trim().Equals(_userData.Id, StringComparison.OrdinalIgnoreCase)))
                             {
-                                DisplayName = parts[3],
-                                Role = "User"
-                            });
+                                var displayName = nameIndex >= 0 ? parts[nameIndex] : "Unknown";
+                                ApplicationAssignments.Add(new ApplicationAssignment
+                                {
+                                    DisplayName = displayName,
+                                    Role = "User"
+                                });
+                            }
                         }
                     }
                 }

--- a/GUI/Views/ApplicationInventoryView.xaml
+++ b/GUI/Views/ApplicationInventoryView.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="MandADiscoverySuite.Views.ApplicationInventoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBox Width="200" Margin="0,0,8,0" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Content="Refresh" Command="{Binding RefreshApplicationsCommand}" />
+            <Button Content="Clear" Command="{Binding ClearSearchCommand}" Margin="8,0,0,0" />
+        </StackPanel>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding ApplicationsView}" AutoGenerateColumns="False" IsReadOnly="True"
+                  HeadersVisibility="Column" CanUserAddRows="False" CanUserDeleteRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
+                <DataGridTextColumn Header="Version" Binding="{Binding Version}" Width="*"/>
+                <DataGridTextColumn Header="Publisher" Binding="{Binding Publisher}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/GUI/Views/ApplicationInventoryView.xaml.cs
+++ b/GUI/Views/ApplicationInventoryView.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows.Controls;
+using MandADiscoverySuite.ViewModels;
+
+namespace MandADiscoverySuite.Views
+{
+    public partial class ApplicationInventoryView : UserControl
+    {
+        public ApplicationInventoryView()
+        {
+            InitializeComponent();
+            DataContext = new ApplicationInventoryViewModel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map applications to users via IDs in discovery models and CSV loading
- add ApplicationInventoryView with filtering ViewModel
- show user application assignments in new Applications tab

## Testing
- `dotnet build GUI/MandADiscoverySuite.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960d65385883338ee28192c05cbdb0