### PR TITLE
feat(gui): link inventory views in quick actions

### DIFF
--- a/GUI/Controls/QuickActionsBar.xaml
+++ b/GUI/Controls/QuickActionsBar.xaml
@@ -277,6 +277,8 @@
                     <MenuItem Header="📊 New Dashboard" Command="{Binding NewDashboardCommand}"/>
                     <MenuItem Header="🔍 New Discovery" Command="{Binding NewDiscoveryCommand}"/>
                     <MenuItem Header="📈 New Report" Command="{Binding NewReportCommand}"/>
+                    <MenuItem Header="📦 Application Inventory" Command="{Binding ShowApplicationInventoryCommand}"/>
+                    <MenuItem Header="🖥️ Asset Inventory" Command="{Binding ShowAssetInventoryCommand}"/>
                     <Separator/>
                     <MenuItem Header="📂 Open File" Command="{Binding OpenFileCommand}"/>
                     <MenuItem Header="💾 Save All" Command="{Binding SaveAllCommand}"/>

--- a/GUI/ViewModels/QuickActionsBarViewModel.cs
+++ b/GUI/ViewModels/QuickActionsBarViewModel.cs
@@ -122,6 +122,8 @@ namespace MandADiscoverySuite.ViewModels
         public ICommand NewDashboardCommand { get; private set; }
         public ICommand NewDiscoveryCommand { get; private set; }
         public ICommand NewReportCommand { get; private set; }
+        public ICommand ShowApplicationInventoryCommand { get; private set; }
+        public ICommand ShowAssetInventoryCommand { get; private set; }
         public ICommand OpenFileCommand { get; private set; }
         public ICommand SaveAllCommand { get; private set; }
         public ICommand ShowSettingsCommand { get; private set; }
@@ -137,6 +139,8 @@ namespace MandADiscoverySuite.ViewModels
             NewDashboardCommand = new RelayCommand(NewDashboard);
             NewDiscoveryCommand = new RelayCommand(NewDiscovery);
             NewReportCommand = new RelayCommand(NewReport);
+            ShowApplicationInventoryCommand = new RelayCommand(ShowApplicationInventory);
+            ShowAssetInventoryCommand = new RelayCommand(ShowAssetInventory);
             OpenFileCommand = new RelayCommand(OpenFile);
             SaveAllCommand = new RelayCommand(SaveAll);
             ShowSettingsCommand = new RelayCommand(ShowSettings);
@@ -412,6 +416,38 @@ namespace MandADiscoverySuite.ViewModels
             catch (Exception ex)
             {
                 Logger?.LogError(ex, "Error opening help");
+            }
+        }
+
+        private void ShowApplicationInventory()
+        {
+            try
+            {
+                _notificationService?.AddInfo(
+                    "Application Inventory",
+                    "Opening application inventory view...");
+
+                Logger?.LogDebug("Opening application inventory from quick actions");
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogError(ex, "Error opening application inventory");
+            }
+        }
+
+        private void ShowAssetInventory()
+        {
+            try
+            {
+                _notificationService?.AddInfo(
+                    "Asset Inventory",
+                    "Opening asset inventory view...");
+
+                Logger?.LogDebug("Opening asset inventory from quick actions");
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogError(ex, "Error opening asset inventory");
             }
         }
 


### PR DESCRIPTION
## Summary
- surface Application and Asset Inventory via Quick Actions menu
- wire up new commands to show inventory placeholders

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_689691b776f883339cf1a315b2d202b0